### PR TITLE
feat: Container image support via ghcr.io

### DIFF
--- a/.github/workflows/publish-container-image.yml
+++ b/.github/workflows/publish-container-image.yml
@@ -1,0 +1,31 @@
+name: Publish Container image
+on: 
+  push:
+    tags:
+    - 'v*'
+jobs:
+  push_to_registry:
+    name: Push Container image to GitHub container registry
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out the repo
+      uses: actions/checkout@v4
+    - name: Log in to the Container registry
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    - name: Extract metadata (tags, labels)
+      id: meta
+      uses: docker/metadata-action@v5
+      with:
+        images: ghcr.io/${{ github.repository }}
+    - name: Build and push Docker image
+      uses: docker/build-push-action@v5
+      with:
+        context: .
+        file: ./Dockerfile
+        push: true
+        tags: ${{ steps.meta.outputs.tags }}
+        labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,4 +28,4 @@ EXPOSE 8080/tcp
 
 ENV RUST_LOG=info
 
-CMD ["/zumble", "--http-password", "changeme"]
+CMD ["/zumble"] # Password should be passed via args


### PR DESCRIPTION
It requires a `GITHUB_TOKEN` as a secret in repository settings. It only needs registry push permissions to be able to work