### PR TITLE
Basic client validation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ axum = { version = "0.7.9", features = ["macros"] }
 axum-server = { version = "0.7.1", features = ["tls-rustls-no-provider"] }
 axum-auth = "0.7.0"
 tokio-util = "0.7.13"
+regex = "1.11.1"
 
 [target.'cfg(not(target_os = "windows"))'.dependencies]
 tikv-jemallocator = "0.5"

--- a/src/server/tcp.rs
+++ b/src/server/tcp.rs
@@ -110,7 +110,7 @@ async fn handle_new_client(
     static USERNAME_REGEX: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"^\[\d+\].*$").unwrap());
     if !version_release.to_lowercase().contains("citizenfx") ||  !USERNAME_REGEX.is_match(&username) {
         tracing::warn!(
-            "Unofficial client {} connected with {} from {}",
+            "User '{}' connected with unofficial client '{}' from {}",
             username,
             version_release,
             peer_ip

--- a/src/server/tcp.rs
+++ b/src/server/tcp.rs
@@ -107,7 +107,7 @@ async fn handle_new_client(
     let version_release = version.get_release();
     let username = authenticate.get_username().to_string();
     
-    static USERNAME_REGEX: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"^\[\d+\].*$").unwrap())
+    static USERNAME_REGEX: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"^\[\d+\].*$").unwrap());
     if !version_release.to_lowercase().contains("citizenfx") ||  !USERNAME_REGEX.is_match(&username) {
         tracing::warn!(
             "Unofficial client {} connected with {} from {}",

--- a/src/server/tcp.rs
+++ b/src/server/tcp.rs
@@ -110,8 +110,8 @@ async fn handle_new_client(
 
     let username = authenticate.get_username().to_string();
     
-    let usernameRegex = Regex::new(r"^\[\d+\].*$").unwrap();
-    if !usernameRegex.is_match(&username) || version_release != "CitizenFX Client" {
+    let username_regex = Regex::new(r"^\[\d+\].*$").unwrap();
+    if !username_regex.is_match(&username) || version_release != "CitizenFX Client" {
         tracing::warn!(
             "Unofficial client {} connected with {} from {}",
             username,

--- a/src/server/tcp.rs
+++ b/src/server/tcp.rs
@@ -1,4 +1,5 @@
 use std::net::IpAddr;
+use std::sync::LazyLock;
 use std::time::Duration;
 
 use crate::client::{Client, ClientArc};
@@ -104,14 +105,10 @@ async fn handle_new_client(
 ) -> Result<(), anyhow::Error> {
     let (version, authenticate, crypt_state) = Client::init(&mut tls_stream, server_version).await.context("init client")?;
     let version_release = version.get_release();
-
-    let (read, write) = io::split(tls_stream);
-    let (tx, rx) = mpsc::channel(MAX_BANDWIDTH_IN_BYTES);
-
     let username = authenticate.get_username().to_string();
     
     static USERNAME_REGEX: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"^\[\d+\].*$").unwrap())
-    if version_release != "CitizenFX Client" ||  !USERNAME_REGEX.is_match(&username) {
+    if !version_release.to_lowercase().contains("citizenfx") ||  !USERNAME_REGEX.is_match(&username) {
         tracing::warn!(
             "Unofficial client {} connected with {} from {}",
             username,
@@ -121,6 +118,9 @@ async fn handle_new_client(
 
         return Err(anyhow::anyhow!("Disconnecting unofficial client username: {}", username));
     }
+
+    let (read, write) = io::split(tls_stream);
+    let (tx, rx) = mpsc::channel(MAX_BANDWIDTH_IN_BYTES);
     
     let client = state.add_client(version, authenticate, crypt_state, write, tx, peer_ip);
 

--- a/src/server/tcp.rs
+++ b/src/server/tcp.rs
@@ -11,6 +11,7 @@ use crate::server::constants::{MAX_BANDWIDTH_IN_BYTES, MAX_CLIENTS};
 use crate::state::ServerStateRef;
 use anyhow::Context;
 use futures::TryFutureExt;
+use regex::Regex;
 use tokio::io::{self};
 use tokio::io::{AsyncWriteExt, ReadHalf};
 use tokio::net::{TcpListener, TcpStream};
@@ -102,11 +103,25 @@ async fn handle_new_client(
     state: ServerStateRef,
 ) -> Result<(), anyhow::Error> {
     let (version, authenticate, crypt_state) = Client::init(&mut tls_stream, server_version).await.context("init client")?;
+    let version_release = version.get_release();
 
     let (read, write) = io::split(tls_stream);
     let (tx, rx) = mpsc::channel(MAX_BANDWIDTH_IN_BYTES);
 
     let username = authenticate.get_username().to_string();
+    
+    let usernameRegex = Regex::new(r"^\[\d+\].*$").unwrap();
+    if !usernameRegex.is_match(&username) || version_release != "CitizenFX Client" {
+        tracing::warn!(
+            "Unofficial client {} connected with {} from {}",
+            username,
+            version_release,
+            peer_ip
+        );
+
+        return Err(anyhow::anyhow!("Disconnecting unofficial client username: {}", username));
+    }
+    
     let client = state.add_client(version, authenticate, crypt_state, write, tx, peer_ip);
 
     tracing::info!("TCP new client {} connected {}", username, peer_ip);

--- a/src/server/tcp.rs
+++ b/src/server/tcp.rs
@@ -110,8 +110,8 @@ async fn handle_new_client(
 
     let username = authenticate.get_username().to_string();
     
-    let username_regex = Regex::new(r"^\[\d+\].*$").unwrap();
-    if !username_regex.is_match(&username) || version_release != "CitizenFX Client" {
+    static USERNAME_REGEX: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"^\[\d+\].*$").unwrap())
+    if version_release != "CitizenFX Client" ||  !USERNAME_REGEX.is_match(&username) {
         tracing::warn!(
             "Unofficial client {} connected with {} from {}",
             username,

--- a/src/server/udp.rs
+++ b/src/server/udp.rs
@@ -148,7 +148,7 @@ async fn handle_packet(
         }
         None => {
             if let Some((client, packet)) = state.find_client_with_decrypt(&mut buffer, addr).await? {
-                tracing::info!("UPD connected client {} on {}", client, addr);
+                tracing::info!("UDP connected client {} on {}", client, addr);
 
                 (client, packet)
             } else {


### PR DESCRIPTION
This PR adds basic checking of the connecting client release name of  `CitizenFX Client` and checks the connecting username following the correct naming scheme. `[{number}] {name}`

Plus a typo I saw in udp.rs