### PR TITLE
fix: Increase size of VoiceTargetArray to 30

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -29,7 +29,7 @@ use tokio_util::sync::CancellationToken;
 pub type ClientArc = Arc<Client>;
 pub type WeakClient = Weak<Client>;
 
-type VoiceTargetArray = [Arc<VoiceTarget>; 29];
+type VoiceTargetArray = [Arc<VoiceTarget>; 30];
 
 #[derive(Debug, Default)]
 pub struct NetStats {


### PR DESCRIPTION
The array was mistakenly sized to 29 it seems.

Target 0 and 31 aren't valid, so target 30 would be indexed at 29, which would require an array of size 30.

This aligns with the errors I was getting in the console saying target 30 isn't valid (with the comment above it saying that that error should never occur)